### PR TITLE
Implement gsheet insert utility

### DIFF
--- a/Bot_App/services/gsheet.py
+++ b/Bot_App/services/gsheet.py
@@ -1,2 +1,23 @@
-def insert_data(sheet, row, values):
-    pass
+"""Utilities for interacting with Google Sheets."""
+
+from typing import Sequence
+
+
+def insert_data(sheet, row: int, values: Sequence):
+    """Insert values into a worksheet at the given row.
+
+    Parameters
+    ----------
+    sheet : Any
+        Worksheet-like object with an ``insert_row`` method.
+    row : int
+        Target row index starting at 1.
+    values : Sequence
+        Data to insert in the row.
+    """
+    if sheet is None:
+        raise ValueError("sheet cannot be None")
+    if row < 1:
+        raise ValueError("row must be >= 1")
+
+    sheet.insert_row(list(values), row)

--- a/Bot_App/tests/test_gsheet.py
+++ b/Bot_App/tests/test_gsheet.py
@@ -1,0 +1,9 @@
+from unittest.mock import MagicMock
+
+from Bot_App.services.gsheet import insert_data
+
+
+def test_insert_data_calls_insert_row():
+    sheet = MagicMock()
+    insert_data(sheet, 2, ["a", "b"])
+    sheet.insert_row.assert_called_once_with(["a", "b"], 2)


### PR DESCRIPTION
## Summary
- implement `insert_data` helper in `Bot_App.services.gsheet`
- add tests for gsheet helper

## Testing
- `black Bot_App/services/gsheet.py Bot_App/tests/test_gsheet.py`
- `flake8 Bot_App/services/gsheet.py Bot_App/tests/test_gsheet.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685067208e0c8323aeae35496908e2db