### PR TITLE
Fix duplicate check_time_of_day and add tests

### DIFF
--- a/Bot_App/config/secrets.py
+++ b/Bot_App/config/secrets.py
@@ -5,7 +5,9 @@ import logging
 from datetime import datetime, timezone, timedelta
 from dotenv import load_dotenv
 
-logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s"
+)
 
 
 def get_secret(key, FILE_PATH="", default=None):
@@ -20,37 +22,51 @@ def get_secret(key, FILE_PATH="", default=None):
         return default
 
 
-def retry_request(request_func, retries=3, delay=5, backoff=2, retry_on=(requests.exceptions.RequestException,), raise_on_fail=False):
+def retry_request(
+    request_func,
+    retries=3,
+    delay=5,
+    backoff=2,
+    retry_on=(requests.exceptions.RequestException,),
+    raise_on_fail=False,
+):
+    last_exception = None
     for attempt in range(1, retries + 1):
         try:
             return request_func()
-        except retry_on as e:
-            logging.warning(f"[Attempt {attempt}] Request failed: {e}. Retrying in {delay}s...")
+        except retry_on as exc:  # noqa: E501
+            last_exception = exc
+            logging.warning(
+                "[Attempt %s] Request failed: %s. Retrying in %ss...",
+                attempt,
+                exc,
+                delay,
+            )
             time.sleep(delay)
             delay *= backoff
 
     logging.error("All retry attempts failed.")
-    if raise_on_fail:
-        raise e
+    if raise_on_fail and last_exception is not None:
+        raise last_exception
     return None
 
 
 def get_start_time(delta=1):
     now = datetime.now(timezone.utc)
-    return now.strftime('%Y-%m-%dT%H:%M:%S.000Z')
+    return now.strftime("%Y-%m-%dT%H:%M:%S.000Z")
 
 
 def get_end_time(delta=1):
     now = datetime.now(timezone.utc)
     past = now - timedelta(hours=delta)
-    return past.strftime('%Y-%m-%dT%H:%M:%S.000Z')
+    return past.strftime("%Y-%m-%dT%H:%M:%S.000Z")
 
 
 def get_current_time():
-    return datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.000Z')
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
 
 
-def flatten_dict(d, parent_key='', sep='.'):
+def flatten_dict(d, parent_key="", sep="."):
     items = []
     for k, v in d.items():
         new_key = f"{parent_key}{sep}{k}" if parent_key else k
@@ -69,11 +85,6 @@ def check_time_of_week(day, hour):
 def check_time_of_day(hour, minute):
     now = datetime.now()
     return now.hour == hour and now.minute == minute
-
-def check_time_of_day(hour):
-    now = datetime.now()
-    logging.debug(f"{now.hour} : {hour}")
-    return now.hour == hour
 
 
 def check_file_changed(file_path, last_modified=None):
@@ -95,6 +106,7 @@ def get_file_last_modified(file_path):
 
 def str_to_bool(value):
     return str(value).strip().lower() == "true"
+
 
 def get_date():
     return datetime.now(timezone.utc).strftime("%m / %d")

--- a/Bot_App/tests/test_secrets.py
+++ b/Bot_App/tests/test_secrets.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+from Bot_App.config import secrets
+
+
+def test_check_time_of_day_true(monkeypatch):
+    """Check function returns True when hour and minute match."""
+
+    class DummyDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2024, 1, 1, 10, 15)
+
+    monkeypatch.setattr(secrets, "datetime", DummyDatetime)
+    assert secrets.check_time_of_day(10, 15)
+
+
+def test_check_time_of_day_false(monkeypatch):
+    """Check function returns False when hour/minute don't match."""
+
+    class DummyDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2024, 1, 1, 10, 15)
+
+    monkeypatch.setattr(secrets, "datetime", DummyDatetime)
+    assert not secrets.check_time_of_day(9, 30)


### PR DESCRIPTION
## Summary
- remove the duplicate `check_time_of_day` implementation
- refactor `retry_request` for clarity and lint compliance
- add unit tests for `check_time_of_day`

## Testing
- `flake8 Bot_App/tests/test_secrets.py`
- `flake8 Bot_App/config/secrets.py | head`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850670e8a9c8323a0929e651dcd4078