### PR TITLE
Fix README usage and add example entry point

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,14 +27,11 @@ pip install git+https://github.com/CrowMother/Bot_framework.git
 
 ## Usage
 
-This framework provides a structured approach to building bots. The main application code resides in the `Bot_App` directory, with source code in the `src` directory and tests in the `tests` directory. To get started, navigate to the `Bot_App` directory and run the main application file:
+This framework provides a structured approach to building bots. The source code lives in the `src` directory and tests in the `tests` directory. An example entry point is provided in `src/Bot_App/main.py`. After installing the package (or setting `PYTHONPATH=src`), run it with:
 
 ```bash
-cd Bot_App
-python main.py
+python -m Bot_App.main
 ```
-
-Replace `main.py` with the actual entry point of your bot application.
 
 ## Contributing
 
@@ -47,4 +44,3 @@ This project is licensed under the MIT License. See the `LICENSE` file for more 
 ## Contact
 
 For questions or suggestions, please open an issue in this repository.
-``` 

--- a/src/Bot_App/main.py
+++ b/src/Bot_App/main.py
@@ -1,0 +1,10 @@
+from Bot_App import util
+
+
+def main():
+    logger = util.setup_logging()
+    logger.info("Bot Framework entry point running")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple `main.py` example under `src/Bot_App`
- update the Usage section in the README to point to the new entry point
- remove stray closing code block at the end of the README

## Testing
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'gspread')*


------
https://chatgpt.com/codex/tasks/task_e_68506cc278fc8323a6e5465b86cf86b3